### PR TITLE
async_hooks instead of cps (pls not compatible with mongoose)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-var cls = require('continuation-local-storage');
-var createNamespace = cls.createNamespace;
-var mtMongooseSessionSet = createNamespace('mt-mongoose-session');
+const { AsyncLocalStorage } = require('async_hooks');
+var mtMongooseStorage = new AsyncLocalStorage();
 var defaultDb = null;
 var systemDb = null;
-var getNamespace = cls.getNamespace;
 var MTMongoose = function () {
 };
 //Default tenant db which is used to perform useDB operation.
@@ -17,16 +15,11 @@ MTMongoose.prototype.setGlobalDB = function (_systemDb) {
 };
 //Method used to set
 MTMongoose.prototype.setTenantId = function (req, res, next) {
-    mtMongooseSessionSet.run(function () {
-        mtMongooseSessionSet.set("tenant_id", req._tid);
-        next();
-    });
+    mtMongooseStorage.run(req['_tid'], next);
 };
 
 MTMongoose.prototype.getTenantId = function () {
-    var mtMongooseSessionGet = getNamespace('mt-mongoose-session');
-    var tenant_id = mtMongooseSessionGet.get("tenant_id");
-    return tenant_id;
+    return mtMongooseStorage.getStore();
 };
 
 MTMongoose.prototype.getMTModel = function (schemaObj) {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "keywords": ["mongoose"],
   "author": "BabuSrithar",
   "dependencies": {
-    "continuation-local-storage":"3.1.7",
-    "mongoose":"5.7.8"
   },
   "devDependencies": {
-
+  },
+  "peerDependencies": {
+    "mongoose":"^5.7.8"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
using now node's async_hooks instead of cls library so that context d…oesn't get lost after mongoose queries (mongoose doesn't work with cls)